### PR TITLE
fix: set gunicorn working directory

### DIFF
--- a/nix/modules/nixos/puka.nix
+++ b/nix/modules/nixos/puka.nix
@@ -91,6 +91,7 @@ in
         DynamicUser = true;
         StateDirectory = "puka";
         RuntimeDirectory = "puka";
+        WorkingDirectory = "/var/run/puka";
 
         BindReadOnlyPaths = [
           "${


### PR DESCRIPTION
GitHub action is failing with gunicorn control-server socket being
Created in read-only dir.