### PR TITLE
feat: change ty check output format and error handling

### DIFF
--- a/nix/packages/venv.nix
+++ b/nix/packages/venv.nix
@@ -30,7 +30,7 @@ pythonSet.mkVirtualEnv "puka-env" workspace.deps.default
         dontInstall = true;
         buildPhase = ''
           runHook preBuild
-          ty check  --output-format=github --exit-zero | tee $out 2>&1
+          ty check  --output-format=concise --error-on-warning | tee $out 2>&1
           runHook postBuild
         '';
       };


### PR DESCRIPTION
Change ty check from github to concise output format and replace
--exit-zero with --error-on-warning to make the build fail on
warnings instead of always succeeding.